### PR TITLE
Fixed grammar error on launch page text

### DIFF
--- a/src/i18n/locales/en/auth.ts
+++ b/src/i18n/locales/en/auth.ts
@@ -1,5 +1,5 @@
 export const auth = {
-  launch1: `Keep track of every interaction with your friend and family!`,
+  launch1: `Keep track of every interaction with your friends and family!`,
   launch2: `Remember when you last called, what you talked about, the name of their kids or what they prefer to eat!`,
   signinTitle: `Sign in with your account`,
   yourEmail: 'Your email',

--- a/src/pages/Auth/Launch/__tests__/__snapshots__/Launch.spec.tsx.snap
+++ b/src/pages/Auth/Launch/__tests__/__snapshots__/Launch.spec.tsx.snap
@@ -42,7 +42,7 @@ exports[`Components Launch should renders correctly 1`] = `
         }
       }
     >
-      Keep track of every interaction with your friend and family!
+      Keep track of every interaction with your friends and family!
     </ForwardRef(Text)>
     <ForwardRef(Text)
       style={


### PR DESCRIPTION
The phrase 'friend and family' is awkward in English because 'friend' refers to a single person whereas 'family' refers to a group of people.

Changing to 'friends and family' for a more natural English phrasing.